### PR TITLE
Removed loops over batch sizes

### DIFF
--- a/src/kernels.cuh
+++ b/src/kernels.cuh
@@ -1,194 +1,169 @@
 #include "utils.cuh"
 #include <math.h>
 
-template<typename dt, typename dtc>
-__global__ void cc2k(
-        const dt *x_ori,
-        const dt *x_loc,
-        const int kH,
-        const int kW,
-        const int rH,
-        const int rW,
-        const int patch,
-        const int channels,
-        const int height,
-        const int width,
-        const int per_channel,
-        dt *y
-) {
-    // x_ori, x_loc: {c, h, w}
-    // y: {h, w, k^2}
-    for (int indexO = blockIdx.x; indexO < per_channel; indexO += gridDim.x) {
-        const int w_ori = indexO % width - rW;
-        const int h_ori = indexO / width - rH;
+template <typename dt, typename dtc>
+__global__ void cc2k(const dt *x_ori, const dt *x_loc, const int kH,
+                     const int kW, const int rH, const int rW, const int patch,
+                     const int channels, const int height, const int width,
+                     const int per_channel, dt *y) {
+  // x_ori, x_loc: {b, c, h, w}
+  // y: {b, h, w, k^2}
+  const int batch_offset = blockIdx.y * channels * per_channel;
+  const int batch_offset_out = blockIdx.y * per_channel * patch;
+  // Block: One thread per pixel in the patch (kH * kW)
+  // Each block computes the result for one pixel
+  for (int indexO = blockIdx.x; indexO < per_channel; indexO += gridDim.x) {
+    // offsets of the output pixel (has no channels)
+    const int w_ori = indexO % width - rW;
+    const int h_ori = indexO / width - rH;
 
-        KERNEL_LOOP(indexK, patch) {
-            const int w = w_ori + indexK % kW;
-            const int h = h_ori + indexK / kW;
-            dtc val = dtc(0);
+    // Each thread computes the result for its pixel in the block
+    // where the block spans the kernel size (patch).
+    KERNEL_LOOP(indexK, patch) {
+      // offsets of input pixels in the kernel
+      const int w = w_ori + indexK % kW;
+      const int h = h_ori + indexK / kW;
+      dtc val{0};
 
-            if (h > -1 && h < height && w > -1 && w < width) {
-                const dt *p_ori = x_ori + indexO;
-                const dt *p_loc = x_loc + h * width + w;
-                for (int c = 0; c < channels; ++c) {
-                    val += static_cast<dtc> (__ldg(p_ori) * __ldg(p_loc));
-                    p_ori += per_channel;
-                    p_loc += per_channel;
-                }
-            }
-            y[indexO * patch + indexK] = static_cast<dt> (val);
+      // coordinates can be out of bounds for some threads
+      if (h > -1 && h < height && w > -1 && w < width) {
+        const dt *p_ori =
+            x_ori + batch_offset + indexO; // target pixel channel=0
+        const dt *p_loc =
+            x_loc + batch_offset + h * width + w; // patch pixel channel=0
+        // Accumulate over channels
+        for (int c = 0; c < channels; ++c) {
+          val += static_cast<dtc>(__ldg(p_ori) * __ldg(p_loc));
+          p_ori += per_channel;
+          p_loc += per_channel;
         }
+      }
+      y[batch_offset_out + indexO * patch + indexK] = static_cast<dt>(val);
     }
+  }
 }
 
-template<typename dt, typename dtc>
-__global__ void ck2c_ori(
-        const dt *x_loc,
-        const dt *x_weight,
-        const int kH,
-        const int kW,
-        const int rH,
-        const int rW,
-        const int patch,
-        const int height,
-        const int width,
-        const int per_channel,
-        const int per_inp,
-        dt *y
-) {
-    // x_loc: {c, h, w}
-    // x_weight: {h, w, k^2}
-    // y: {c, h, w}
-    KERNEL_LOOP1d(index, per_inp) {
-        const int index_ = index % per_channel;
-        const int w_ori = index_ % width - rW;
-        const int h_ori = index_ / width - rH;
-        const dt *p_weight = x_weight + index_ * patch;
-        const dt *p_loc = x_loc + index - index_;
-        dtc val = dtc(0);
+template <typename dt, typename dtc>
+__global__ void ck2c_ori(const dt *x_loc, const dt *x_weight, const int kH,
+                         const int kW, const int rH, const int rW,
+                         const int patch, const int channels, const int height,
+                         const int width, const int per_channel,
+                         const int per_inp, dt *y) {
+  // x_loc: {b, c, h, w}
+  // x_weight: {b, h, w, k^2}
+  // y: {b, c, h, w}
+  const int batch_offset = blockIdx.y * channels * per_channel;
+  const int batch_offset_w = blockIdx.y * per_channel * patch;
+  // Each thread computes the result for one output in the block
+  KERNEL_LOOP1d(index, per_inp) {
+    const int index_ = index % per_channel; // spatial index (no channels)
+    const int w_ori = index_ % width - rW;  // left side of kernel x
+    const int h_ori = index_ / width - rH;  // top side of kernel y
+    const dt *p_weight = x_weight + batch_offset_w +
+                         index_ * patch; // start of kernel-patch in x_weight
+    const dt *p_loc =
+        x_loc + batch_offset + index - index_; // pixel address for channel=0
+    dtc val{0};
 
-        for (int indexK = 0; indexK < patch; ++indexK) {
-            const int w = w_ori + indexK % kW;
-            const int h = h_ori + indexK / kW;
-            if (h > -1 && h < height && w > -1 && w < width) {
-                val += static_cast<dtc> (__ldg(p_loc + width * h + w) *
-                        __ldg(p_weight + indexK));
-            }
-        }
-        y[index] = static_cast<dt> (val);
+    // accumulate over kernel size (k^2)
+    for (int indexK = 0; indexK < patch; ++indexK) {
+      const int w = w_ori + indexK % kW;  // index in kernel x
+      const int h = h_ori + indexK / kW;  // index in kernel y
+      // w_ori and h_ori can out of bounds
+      if (h > -1 && h < height && w > -1 && w < width) {
+        val += static_cast<dtc>(__ldg(p_loc + width * h + w) *
+                                __ldg(p_weight + indexK));
+      }
     }
+    y[index + batch_offset] = static_cast<dt>(val);
+  }
 }
 
-template<typename dt, typename dtc>
-__global__ void ck2c_loc(
-        const dt *x_ori,
-        const dt *x_weight,
-        const int kH,
-        const int kW,
-        const int rH,
-        const int rW,
-        const int patch,
-        const int height,
-        const int width,
-        const int per_channel,
-        const int per_inp,
-        dt *y
-) {
-    // x_ori: {c, h, w}
-    // x_weight: {h, w, k^2}
-    // y: {c, h, w}
-    KERNEL_LOOP1d(index, per_inp) {
-        const int index_ = index % per_channel;
-        const int w_ori = index_ % width + rW;
-        const int h_ori = index_ / width + rH;
-        const dt *p_ori = x_ori + index - index_;
-        dtc val = dtc(0);
+template <typename dt, typename dtc>
+__global__ void ck2c_loc(const dt *x_ori, const dt *x_weight, const int kH,
+                         const int kW, const int rH, const int rW,
+                         const int patch, const int channels, const int height, const int width,
+                         const int per_channel, const int per_inp, dt *y) {
+  // x_ori: {b, c, h, w}
+  // x_weight: {b, h, w, k^2}
+  // y: {b, c, h, w}
+  const int batch_offset =
+      blockIdx.y * channels * width * height;
+  const int batch_offset_w = blockIdx.y * height * width * patch;
+  // Each thread computes the result for one output in the block
+  KERNEL_LOOP1d(index, per_inp) {
+    const int index_ = index % per_channel;  // spatial index (no channels)
+    const int w_ori = index_ % width + rW;  // right side of kernel x
+    const int h_ori = index_ / width + rH;  // bottom of kernel y
+    const dt *p_ori = x_ori + batch_offset + index - index_;  // pixel address for channel=0
+    dtc val{0};
 
-        for (int indexK = 0; indexK < patch; ++indexK) {
-            const int w = w_ori - indexK % kW;
-            const int h = h_ori - indexK / kW;
-            const int indexW = width * h + w;
+    // accumulate over kernel size (k^2)
+    for (int indexK = 0; indexK < patch; ++indexK) {
+      const int w = w_ori - indexK % kW;  // index in kernel x
+      const int h = h_ori - indexK / kW;  // index in kernel y
+      const int indexW = width * h + w;  // linear index in kernel
 
-            if (h > -1 && h < height && w > -1 && w < width) {
-                val += static_cast<dtc> (__ldg(p_ori + indexW) *
-                        __ldg(x_weight + indexW * patch + indexK));
-            }
-        }
-        y[index] = static_cast<dt> (val);
+      // w_ori and h_ori can be out of bounds
+      if (h > -1 && h < height && w > -1 && w < width) {
+        val += static_cast<dtc>(
+            __ldg(p_ori + indexW) *
+            __ldg(x_weight + batch_offset_w + indexW * patch + indexK));
+      }
     }
+    y[index + batch_offset] = static_cast<dt>(val);
+  }
 }
 
 //////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////
 
-template<typename dt, typename dtc>
-void f_cc2k(
-        cudaStream_t stream,
-        const dt *x_ori,
-        const dt *x_loc,
-        const int kH,
-        const int kW,
-        const int rH,
-        const int rW,
-        const int patch,
-        const int channels,
-        const int height,
-        const int width,
-        const int per_channel,
-        dt *y) {
-    cc2k<dt, dtc> <<< min(per_channel, MAX_PIXELS_2d), CUDA_NUM_THREADS, 0, stream >>> (
-            x_ori, x_loc,
-                    kH, kW, rH, rW,
-                    patch, channels,
-                    height, width, per_channel,
-                    y);
+template <typename dt, typename dtc>
+void f_cc2k(cudaStream_t stream, const dt *x_ori, const dt *x_loc, const int kH,
+            const int kW, const int rH, const int rW, const int patch,
+            const int channels, const int height, const int width,
+            const int per_channel, const int batch, dt *y) {
+  // total threads needed: patch * h * w 
+  // grid: h * w
+  // block_dim: min(max(32, patch), 1024)
+  const int threads_per_block = WARP_SIZE * GET_BLOCKS(patch, WARP_SIZE);
+  dim3 block_dim(min(threads_per_block, CUDA_NUM_THREADS));
+  dim3 grid_dim(per_channel, batch);
+  cc2k<dt, dtc><<<grid_dim, block_dim, 0, stream>>>(
+      x_ori, x_loc, kH, kW, rH, rW, patch, channels, height, width, per_channel,
+      y);
 }
 
-template<typename dt, typename dtc>
-void f_ck2c_ori(
-        cudaStream_t stream,
-        const dt *x_loc,
-        const dt *x_weight,
-        const int kH,
-        const int kW,
-        const int rH,
-        const int rW,
-        const int patch,
-        const int channels,
-        const int height,
-        const int width,
-        const int per_channel,
-        const int per_inp,
-        dt *y) {
-    ck2c_ori<dt, dtc> <<< GET_BLOCKS(min(per_inp, MAX_PIXELS_3d)), CUDA_NUM_THREADS, 0, stream >>> (
-            x_loc, x_weight,
-                    kH, kW, rH, rW,
-                    patch, height, width,
-                    per_channel, per_inp,
-                    y);
-
+template <typename dt, typename dtc>
+void f_ck2c_ori(cudaStream_t stream, const dt *x_loc, const dt *x_weight,
+                const int kH, const int kW, const int rH, const int rW,
+                const int patch, const int channels, const int height,
+                const int width, const int per_channel, const int per_inp,
+                const int batch, dt *y) {
+  // total threads needed: c * h * w 
+  // grid: h * w
+  // block_dim: min(max(32, c), 1024)
+  const int threads_per_block = WARP_SIZE * GET_BLOCKS(channels, WARP_SIZE);
+  dim3 block_dim(min(threads_per_block, CUDA_NUM_THREADS));
+  dim3 grid_dim(GET_BLOCKS(per_inp, block_dim.x), batch);
+  ck2c_ori<dt, dtc><<<grid_dim, block_dim, 0, stream>>>(
+      x_loc, x_weight, kH, kW, rH, rW, patch, channels, height, width,
+      per_channel, per_inp, y);
 }
 
-template<typename dt, typename dtc>
-void f_ck2c_loc(
-        cudaStream_t stream,
-        const dt *x_ori,
-        const dt *x_weight,
-        const int kH,
-        const int kW,
-        const int rH,
-        const int rW,
-        const int patch,
-        const int channels,
-        const int height,
-        const int width,
-        const int per_channel,
-        const int per_inp,
-        dt *y) {
-    ck2c_loc<dt, dtc> <<< GET_BLOCKS(min(per_inp, MAX_PIXELS_3d)), CUDA_NUM_THREADS, 0, stream >>> (
-            x_ori, x_weight,
-                    kH, kW, rH, rW,
-                    patch, height, width,
-                    per_channel, per_inp,
-                    y);
+template <typename dt, typename dtc>
+void f_ck2c_loc(cudaStream_t stream, const dt *x_ori, const dt *x_weight,
+                const int kH, const int kW, const int rH, const int rW,
+                const int patch, const int channels, const int height,
+                const int width, const int per_channel, const int per_inp,
+                const int batch, dt *y) {
+  // total threads needed: c * h * w 
+  // grid: h * w
+  // block_dim: min(max(32, c), 1024)
+  const int threads_per_block = WARP_SIZE * GET_BLOCKS(channels, WARP_SIZE);
+  dim3 block_dim(min(threads_per_block, CUDA_NUM_THREADS));
+  dim3 grid_dim(GET_BLOCKS(per_inp, block_dim.x), batch);
+  ck2c_loc<dt, dtc><<<grid_dim, block_dim, 0, stream>>>(
+      x_ori, x_weight, kH, kW, rH, rW, patch, channels, height, width, per_channel,
+      per_inp, y);
 }

--- a/src/similar.cu
+++ b/src/similar.cu
@@ -1,92 +1,59 @@
 #include "kernels.cuh"
 
-torch::Tensor similar_cuda_forward(
-        const torch::Tensor &x_ori,
-        const torch::Tensor &x_loc,
-        const int kH, const int kW
-) {
-    TypeCheck(x_ori);
-    TypeCheck(x_loc);
-    const int batch = x_ori.size(0);
-    const int channels = x_ori.size(1);
-    const int height = x_ori.size(2);
-    const int width = x_ori.size(3);
+torch::Tensor similar_cuda_forward(const torch::Tensor &x_ori,
+                                   const torch::Tensor &x_loc, const int kH,
+                                   const int kW) {
+  TypeCheck(x_ori);
+  TypeCheck(x_loc);
+  const int batch = x_ori.size(0);
+  const int channels = x_ori.size(1);
+  const int height = x_ori.size(2);
+  const int width = x_ori.size(3);
 
-    const int rH = kH >> 1;
-    const int rW = kW >> 1;
-    const int patch = kH * kW;
-    const int per_channel = height * width;
-    const int per_input = per_channel * channels;
-    const int per_output = height * width * patch;
-    auto output = torch::empty({batch, height, width, patch}, x_ori.options());
+  const int rH = kH / 2;
+  const int rW = kW / 2;
+  const int patch = kH * kW;
+  const int per_channel = height * width;
+  auto output = torch::empty({batch, height, width, patch}, x_ori.options());
 
-    int start_inp = 0, start_out = 0;
-    for (int i = 0; i < batch; ++i) {
-        f_cc2k<float, double>(
-                at::cuda::getCurrentCUDAStream(),
-                x_ori.data_ptr<float>() + start_inp,
-                x_loc.data_ptr<float>() + start_inp,
-                kH, kW, rH, rW,
-                patch, channels, height, width,
-                per_channel,
-                output.data_ptr<float>() + start_out
-        );
-        start_inp += per_input;
-        start_out += per_output;
-    }
+  f_cc2k<float, double>(at::cuda::getCurrentCUDAStream(),
+                        x_ori.data_ptr<float>(), x_loc.data_ptr<float>(), kH,
+                        kW, rH, rW, patch, channels, height, width, per_channel,
+                        batch, output.data_ptr<float>());
 
-    return output;
+  return output;
 }
 
 //////////////////////////////////////////////////////////////
 
-torch::Tensor similar_cuda_backward(
-        const torch::Tensor &x,
-        const torch::Tensor &grad_out,
-        const int kH, const int kW,
-        const bool is_ori
-) {
-    TypeCheck(x);
-    const int batch = x.size(0);
-    const int channels = x.size(1);
-    const int height = x.size(2);
-    const int width = x.size(3);
+torch::Tensor similar_cuda_backward(const torch::Tensor &x,
+                                    const torch::Tensor &grad_out, const int kH,
+                                    const int kW, const bool is_ori) {
+  TypeCheck(x);
+  const int batch = x.size(0);
+  const int channels = x.size(1);
+  const int height = x.size(2);
+  const int width = x.size(3);
 
-    const int rH = kH >> 1;
-    const int rW = kW >> 1;
-    const int patch = kH * kW;
-    const int per_channel = height * width;
-    const int per_input = per_channel * channels;
+  const int rH = kH / 2;
+  const int rW = kW / 2;
+  const int patch = kH * kW;
+  const int per_channel = height * width;
+  const int per_input = per_channel * channels;
 
-    auto grad_inp = torch::empty({batch, channels, height, width}, x.options());
+  auto grad_inp = torch::empty({batch, channels, height, width}, x.options());
 
-    int start_inp = 0;
-    for (int i = 0; i < batch; ++i) {
-        auto grad_out_row = grad_out.select(0, i);
-        if (is_ori) {
-            f_ck2c_ori<float, double>(
-                    at::cuda::getCurrentCUDAStream(),
-                    x.data_ptr<float>() + start_inp,
-                    grad_out_row.data_ptr<float>(),
-                    kH, kW, rH, rW,
-                    patch, channels,
-                    height, width,
-                    per_channel, per_input,
-                    grad_inp.data_ptr<float>() + start_inp
-            );
-        } else {
-            f_ck2c_loc<float, double>(
-                    at::cuda::getCurrentCUDAStream(),
-                    x.data_ptr<float>() + start_inp,
-                    grad_out_row.data_ptr<float>(),
-                    kH, kW, rH, rW,
-                    patch, channels,
-                    height, width,
-                    per_channel, per_input,
-                    grad_inp.data_ptr<float>() + start_inp
-            );
-        }
-        start_inp += per_input;
-    }
-    return grad_inp;
+  if (is_ori) {
+    f_ck2c_ori<float, double>(
+        at::cuda::getCurrentCUDAStream(), x.data_ptr<float>(),
+        grad_out.data_ptr<float>(), kH, kW, rH, rW, patch, channels, height,
+        width, per_channel, per_input, batch, grad_inp.data_ptr<float>());
+  } else {
+    f_ck2c_loc<float, double>(
+        at::cuda::getCurrentCUDAStream(), x.data_ptr<float>(),
+        grad_out.data_ptr<float>(), kH, kW, rH, rW, patch, channels, height,
+        width, per_channel, per_input, batch, grad_inp.data_ptr<float>());
+  }
+
+  return grad_inp;
 }

--- a/src/utils.cuh
+++ b/src/utils.cuh
@@ -8,6 +8,7 @@
 #define CUDA_NUM_THREADS 1024
 #define MAX_PIXELS_2d 1048576
 #define MAX_PIXELS_3d 16777216
+#define WARP_SIZE 32
 
 #define KERNEL_LOOP(i, I)                              \
 for (int i = threadIdx.x; i < (I); i += blockDim.x)

--- a/src/weighting.cu
+++ b/src/weighting.cu
@@ -1,122 +1,79 @@
 #include "kernels.cuh"
 
-torch::Tensor weighting_cuda_forward(
-        const torch::Tensor &x_ori,
-        const torch::Tensor &x_weight,
-        const int kH, const int kW
-) {
-    TypeCheck(x_ori);
-    TypeCheck(x_weight);
-    const int batch = x_ori.size(0);
-    const int channels = x_ori.size(1);
-    const int height = x_ori.size(2);
-    const int width = x_ori.size(3);
+torch::Tensor weighting_cuda_forward(const torch::Tensor &x_ori,
+                                     const torch::Tensor &x_weight,
+                                     const int kH, const int kW) {
+  TypeCheck(x_ori);
+  TypeCheck(x_weight);
+  const int batch = x_ori.size(0);
+  const int channels = x_ori.size(1);
+  const int height = x_ori.size(2);
+  const int width = x_ori.size(3);
 
-    const int rH = kH >> 1;
-    const int rW = kW >> 1;
-    const int patch = kH * kW;
-    const int per_channel = height * width;
-    const int per_input = per_channel * channels;
-    const int per_output = per_channel * patch;
-    auto output = torch::empty({batch, channels, height, width}, x_ori.options());
+  const int rH = kH / 2;
+  const int rW = kW / 2;
+  const int patch = kH * kW;
+  const int per_channel = height * width;
+  const int per_input = per_channel * channels;
+  auto output = torch::empty({batch, channels, height, width}, x_ori.options());
 
-    int start_inp = 0, start_out = 0;
-    for (int i=0; i<batch; ++i) {
-        f_ck2c_ori<float, double> (
-                at::cuda::getCurrentCUDAStream(),
-                x_ori.data_ptr<float>() + start_inp,
-                x_weight.data_ptr<float>() + start_out,
-                kH, kW, rH, rW,
-                patch, channels,
-                height, width,
-                per_channel, per_input,
-                output.data_ptr<float>() + start_inp
-        );
-        start_inp += per_input;
-        start_out += per_output;
-    }
-
-    return output;
+  f_ck2c_ori<float, double>(
+      at::cuda::getCurrentCUDAStream(), x_ori.data_ptr<float>(),
+      x_weight.data_ptr<float>(), kH, kW, rH, rW, patch, channels, height,
+      width, per_channel, per_input, batch, output.data_ptr<float>());
+  return output;
 }
 
 //////////////////////////////////////////////////////////////
 
-torch::Tensor weighting_cuda_backward_ori(
-        const torch::Tensor &x_weight,
-        const torch::Tensor &grad_out,
-        const int kH, const int kW
-) {
-    TypeCheck(x_weight);
-    const int batch = x_weight.size(0);
-    const int channels = grad_out.size(1);
-    const int height = x_weight.size(1);
-    const int width = x_weight.size(2);
+torch::Tensor weighting_cuda_backward_ori(const torch::Tensor &x_weight,
+                                          const torch::Tensor &grad_out,
+                                          const int kH, const int kW) {
+  TypeCheck(x_weight);
+  const int batch = x_weight.size(0);
+  const int channels = grad_out.size(1);
+  const int height = x_weight.size(1);
+  const int width = x_weight.size(2);
 
-    const int rH = kH >> 1;
-    const int rW = kW >> 1;
-    const int patch = kH * kW;
-    const int per_channel = height * width;
-    const int per_input = per_channel * channels;
-    const int per_output = per_channel * patch;
-    auto grad_ori = torch::empty({batch, channels, height, width}, x_weight.options());
+  const int rH = kH / 2;
+  const int rW = kW / 2;
+  const int patch = kH * kW;
+  const int per_channel = height * width;
+  const int per_input = per_channel * channels;
+  /* const int per_output = per_channel * patch; */
+  auto grad_ori =
+      torch::empty({batch, channels, height, width}, x_weight.options());
 
-    int start_inp = 0, start_out = 0;
-    for (int i=0; i<batch; ++i) {
-        auto grad_out_row = grad_out.select(0, i);
-        f_ck2c_loc<float, double> (
-                at::cuda::getCurrentCUDAStream(),
-                grad_out_row.data_ptr<float>(),
-                x_weight.data_ptr<float>() + start_out,
-                kH, kW, rH, rW,
-                patch, channels,
-                height, width,
-                per_channel, per_input,
-                grad_ori.data_ptr<float>() + start_inp
-        );
-        start_inp += per_input;
-        start_out += per_output;
-    }
+  f_ck2c_loc<float, double>(
+      at::cuda::getCurrentCUDAStream(), grad_out.data_ptr<float>(),
+      x_weight.data_ptr<float>(), kH, kW, rH, rW, patch, channels, height,
+      width, per_channel, per_input, batch, grad_ori.data_ptr<float>());
 
-    return grad_ori;
+  return grad_ori;
 }
 
 //////////////////////////////////////////////////////////////
 
-torch::Tensor weighting_cuda_backward_weight(
-        const torch::Tensor &x_ori,
-        const torch::Tensor &grad_out,
-        const int kH, const int kW
-) {
-    TypeCheck(x_ori);
-    const int batch = x_ori.size(0);
-    const int channels = x_ori.size(1);
-    const int height = x_ori.size(2);
-    const int width = x_ori.size(3);
+torch::Tensor weighting_cuda_backward_weight(const torch::Tensor &x_ori,
+                                             const torch::Tensor &grad_out,
+                                             const int kH, const int kW) {
+  TypeCheck(x_ori);
+  const int batch = x_ori.size(0);
+  const int channels = x_ori.size(1);
+  const int height = x_ori.size(2);
+  const int width = x_ori.size(3);
 
-    const int rH = kH >> 1;
-    const int rW = kW >> 1;
-    const int patch = kH * kW;
-    const int per_channel = height * width;
-    const int per_input = per_channel * channels;
-    const int per_output = per_channel * patch;
-    auto grad_weight = torch::empty({batch, height, width, patch}, x_ori.options());
+  const int rH = kH / 2;
+  const int rW = kW / 2;
+  const int patch = kH * kW;
+  const int per_channel = height * width;
+  auto grad_weight =
+      torch::empty({batch, height, width, patch}, x_ori.options());
 
-    int start_inp = 0, start_out = 0;
-    for (int i=0; i<batch; ++i) {
-        auto grad_out_row = grad_out.select(0, i);
-        f_cc2k<float, double> (
-                at::cuda::getCurrentCUDAStream(),
-                grad_out_row.data_ptr<float>(),
-                x_ori.data_ptr<float>() + start_inp,
-                kH, kW, rH, rW,
-                patch, channels,
-                height, width,
-                per_channel,
-                grad_weight.data_ptr<float>() + start_out
-        );
-        start_inp += per_input;
-        start_out += per_output;
-    }
+  f_cc2k<float, double>(at::cuda::getCurrentCUDAStream(),
+                        grad_out.data_ptr<float>(), x_ori.data_ptr<float>(), kH,
+                        kW, rH, rW, patch, channels, height, width, per_channel,
+                        batch, grad_weight.data_ptr<float>());
 
-    return grad_weight;
+  return grad_weight;
 }

--- a/test/similar.py
+++ b/test/similar.py
@@ -117,9 +117,9 @@ def test_efficiency_backward(h, w, c, kh, kw):
 
 
 if __name__ == '__main__':
-    for im in [128, 64, 32]:
-        for c in [64, 32 ,16]:
-            for block in [21, 11, 5]:
+    for im in [64, 32, 16]:
+        for c in [32 ,16, 8]:
+            for block in [11, 5, 3]:
                 print("input:{} channel:{} block:{}".format(im, c, block))
                 test_correct(im, im, c, block, block)
                 test_efficiency_forward(im, im, c, block, block)

--- a/test/weighting.py
+++ b/test/weighting.py
@@ -134,9 +134,9 @@ def test_efficiency_backward(h, w, c, kh, kw):
 
 
 if __name__ == '__main__':
-    for im in [128, 64, 32]:
-        for c in [64, 32 ,16]:
-            for block in [21, 11, 5]:
+    for im in [64, 32, 16]:
+        for c in [32 ,16, 8]:
+            for block in [11, 5, 3]:
                 print("input:{} channel:{} block:{}".format(im, c, block))
                 test_correct(im, im, c, block, block)
                 test_efficiency_forward(im, im, c, block, block)


### PR DESCRIPTION
Changes:
- Loop over batch dimension was replaced by putting the batch dimension
  into the y dimension of the grid. This limits the maximum possible
  batch size to 2**16.
- Changed block and grid dimensions to prevent unnecessarily large
  blocks that do nothing.
- Removed small limit in grid-sizes in x-direction (MAX_PIXELS_2d,
  MAX_PIXELS_3d). The hardware limit is 2**32 -1 = 4294967295, which is
  way higher. If there was a reason for that limit then I didn't see it.
- Added comments to the kernel code. This is a side effect of a
  debugging session.

Effects:
For large batches of small images the utilization is now way higher.
For the denoise.py test one epoch is much faster.
E.g. On a TITAN X:
torch: 237.0s
old: 160.0s
new: 50.3s

Timing comparison with the test/denoise.py highlight the performance gain of the changes:

| Old kernels Training Stats  |  New kernels Training Stats | Old Evaluation Loss PSNR | New Evaluation Loss PSNR |
| ----------------------------|-----------------------------|-----------------------|-----------------------------|
| Epoch 0:	0.00740	158.7s  |  Epoch 0:	0.00739	50.1s| 0.00737	21.324              |  0.00736	21.332|
| Epoch 1:	0.00593	159.9s  |  Epoch 1:	0.00686	52.7s| 0.00589	22.299              |  0.00683	21.653|
| Epoch 2:	0.00462	159.9s  |  Epoch 2:	0.00613	54.1s| 0.00460	23.376              |  0.00610	22.145|
| Epoch 3:	0.00412	160.0s  |  Epoch 3:	0.00524	54.5s| 0.00411	23.861              |  0.00519	22.849|
| Epoch 4:	0.00396	159.9s  |  Epoch 4:	0.00456	54.3s| 0.00396	24.022              |  0.00454	23.429|
| Epoch 5:	0.00381	160.0s  |  Epoch 5:	0.00417	53.9s| 0.00382	24.179              |  0.00417	23.797|
| Epoch 6:	0.00370	159.9s  |  Epoch 6:	0.00397	53.7s| 0.00368	24.345              |  0.00397	24.011|
| Epoch 7:	0.00363	160.0s  |  Epoch 7:	0.00389	53.5s| 0.00363	24.402              |  0.00402	23.954|
| Epoch 8:	0.00363	160.1s  |  Epoch 8:	0.00380	53.5s| 0.00359	24.449              |  0.00381	24.194|
| Epoch 9:	0.00351	160.0s  |  Epoch 9:	0.00371	53.5s| 0.00353	24.519              |  0.00393	24.058|
| Epoch 10:	0.00350	160.0s  |  Epoch 10:	0.00367	53.5s| 0.00348	24.589              |  0.00364	24.384|
| Epoch 11:	0.00347	160.0s  |  Epoch 11:	0.00360	53.4s| 0.00349	24.578              |  0.00360	24.433|
| Epoch 12:	0.00345	160.0s  |  Epoch 12:	0.00354	53.4s| 0.00342	24.656              |  0.00356	24.487|
| Epoch 13:	0.00341	160.1s  |  Epoch 13:	0.00349	53.4s| 0.00339	24.692              |  0.00350	24.565|
| Epoch 14:	0.00341	160.1s  |  Epoch 14:	0.00344	53.5s| 0.00341	24.668              |  0.00343	24.649|
| Epoch 15:	0.00336	160.0s  |  Epoch 15:	0.00340	53.4s| 0.00335	24.751              |  0.00340	24.680|
| Epoch 16:	0.00335	160.0s  |  Epoch 16:	0.00337	53.5s| 0.00338	24.706              |  0.00335	24.746|
| Epoch 17:	0.00333	160.0s  |  Epoch 17:	0.00339	53.5s| 0.00334	24.765              |  0.00342	24.659|
| Epoch 18:	0.00333	160.0s  |  Epoch 18:	0.00335	53.6s| 0.00330	24.816              |  0.00344	24.633|
| Epoch 19:	0.00331	160.0s  |  Epoch 19:	0.00331	53.5s| 0.00331	24.800              |  0.00333	24.771|
| Epoch 20:	0.00329	160.0s  |  Epoch 20:	0.00329	53.4s| 0.00338	24.715              |  0.00328	24.846|
| Epoch 21:	0.00327	160.0s  |  Epoch 21:	0.00331	53.3s| 0.00332	24.786              |  0.00328	24.844|
| Epoch 22:	0.00327	160.0s  |  Epoch 22:	0.00328	53.3s| 0.00328	24.843              |  0.00328	24.846|
| Epoch 23:	0.00321	160.0s  |  Epoch 23:	0.00322	53.3s| 0.00321	24.942              |  0.00321	24.930|
| Epoch 24:	0.00323	160.2s  |  Epoch 24:	0.00324	53.3s| 0.00320	24.949              |  0.00321	24.935|
| Epoch 25:	0.00320	160.0s  |  Epoch 25:	0.00321	53.5s| 0.00320	24.953              |  0.00321	24.942|
| Epoch 26:	0.00321	160.0s  |  Epoch 26:	0.00322	53.3s| 0.00320	24.950              |  0.00321	24.941|
| Epoch 27:	0.00321	160.0s  |  Epoch 27:	0.00320	53.4s| 0.00320	24.947              |  0.00320	24.945|
| Epoch 28:	0.00319	160.0s  |  Epoch 28:	0.00319	53.2s| 0.00319	24.962              |  0.00321	24.938|
| Epoch 29:	0.00322	160.0s  |  Epoch 29:	0.00323	53.2s| 0.00319	24.957              |  0.00321	24.936|
| Epoch 30:	0.00320	160.0s  |  Epoch 30:	0.00321	53.2s| 0.00320	24.952              |  0.00319	24.957|
| Epoch 31:	0.00319	160.0s  |  Epoch 31:	0.00322	53.2s| 0.00318	24.969              |  0.00319	24.956|
| Epoch 32:	0.00319	160.0s  |  Epoch 32:	0.00320	53.2s| 0.00319	24.963              |  0.00319	24.958|
| Epoch 33:	0.00318	160.0s  |  Epoch 33:	0.00320	53.3s| 0.00318	24.974              |  0.00319	24.968|
| Epoch 34:	0.00319	160.0s  |  Epoch 34:	0.00320	53.3s| 0.00318	24.970              |  0.00318	24.972|
| Epoch 35:	0.00318	160.1s  |  Epoch 35:	0.00320	53.3s| 0.00318	24.980              |  0.00319	24.966|
| Epoch 36:	0.00320	160.2s  |  Epoch 36:	0.00320	53.3s| 0.00318	24.982              |  0.00318	24.969|
| Epoch 37:	0.00318	160.0s  |  Epoch 37:	0.00318	53.3s| 0.00318	24.982              |  0.00318	24.979|
| Epoch 38:	0.00319	160.0s  |  Epoch 38:	0.00318	53.3s| 0.00317	24.987              |  0.00318	24.976|
| Epoch 39:	0.00320	160.0s  |  Epoch 39:	0.00320	53.2s| 0.00319	24.968              |  0.00318	24.978|

Note that usage of shared memory might still help to significantly improve performance further. We might commit that in a future pull request.